### PR TITLE
Using bundler.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ doc
 pkg
 .bundle
 .yardoc
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in gemspec.yml
+gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,3 @@
-require 'rubygems'
 require 'bundler'
 
 Bundler.require :development

--- a/Rakefile
+++ b/Rakefile
@@ -1,40 +1,14 @@
 require 'rubygems'
-require 'rake'
+require 'bundler'
 
-begin
-  gem 'rubygems-tasks', '~> 0.1'
-  require 'rubygems/tasks'
+Bundler.require :development
 
-  Gem::Tasks.new
-rescue LoadError => e
-  warn e.message
-  warn "Run `gem install rubygems-tasks` to install 'rubygems/tasks'."
-end
+require 'rspec/core/rake_task'
 
-begin
-  gem 'rspec', '~> 2.4'
-  require 'rspec/core/rake_task'
+Gem::Tasks.new
 
-  RSpec::Core::RakeTask.new
-rescue LoadError => e
-  task :spec do
-    abort e.message
-  end
-end
+RSpec::Core::RakeTask.new
 task :test => :spec
 task :default => :spec
 
-begin
-  gem 'yard', '~> 0.8'
-  gem 'redcarpet'
-  gem 'github-markup'
-  require 'yard'
-  require 'redcarpet'
-  require 'github-markup'
-
-  YARD::Rake::YardocTask.new
-rescue LoadError => e
-  task :yard do
-    abort e.message
-  end
-end
+YARD::Rake::YardocTask.new

--- a/gemspec.yml
+++ b/gemspec.yml
@@ -12,6 +12,7 @@ homepage: https://github.com/postmodern/digest-crc#readme
 has_yard: true
 
 development_dependencies:
+  rake: '>= 0'
   rubygems-tasks: ~> 0.2
   rspec: ~> 2.4
   yard: ~> 0.8

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,1 @@
-gem 'rspec', '~> 2.4'
-require 'rspec'
+# Specify some spec-helpers and additional requires here.


### PR DESCRIPTION
> Not that many dependencies to warrant Bundler.

Yes, but, for example, I get the following:

``` sh
rake spec
# => Unable to activate rspec-2.14.1, because rspec-core-3.0.0.beta1 conflicts with rspec-core (~> 2.14.0) (Gem::LoadError)
```

Bundler solves this problem with ease. So, it's easy to contribute. =)

And we get neat little Gemfile and Rakefile (without a lot of `require`).

UPD: and without specifying `gem 'xxx', 'vvv'` directly in code too.

UPD2: and without duplication gems versions in the code and `gemspec.yml` too! =)
