### PR TITLE
Silence redifinition warnings

### DIFF
--- a/lib/digest/crc15.rb
+++ b/lib/digest/crc15.rb
@@ -47,7 +47,19 @@ module Digest
 
       buffer
     end
+  end
+end
 
+if RUBY_ENGINE == 'ruby'
+  begin;
+    require 'digest/crc15/crc15_ext'
+    return
+  rescue LoadError
+  end
+end
+
+module Digest
+  class CRC15
     #
     # Updates the CRC15 checksum.
     #
@@ -63,8 +75,4 @@ module Digest
     end
 
   end
-end
-
-if RUBY_ENGINE == 'ruby'
-  begin; require 'digest/crc15/crc15_ext'; rescue LoadError; end
 end

--- a/lib/digest/crc16.rb
+++ b/lib/digest/crc16.rb
@@ -63,7 +63,19 @@ module Digest
 
       buffer
     end
+  end
+end
 
+if RUBY_ENGINE == 'ruby'
+  begin;
+    require 'digest/crc16/crc16_ext'
+    return
+  rescue LoadError
+  end
+end
+
+module Digest
+  class CRC16
     #
     # Updates the CRC16 checksum.
     #
@@ -79,8 +91,4 @@ module Digest
     end
 
   end
-end
-
-if RUBY_ENGINE == 'ruby'
-  begin; require 'digest/crc16/crc16_ext'; rescue LoadError; end
 end

--- a/lib/digest/crc16_ccitt.rb
+++ b/lib/digest/crc16_ccitt.rb
@@ -43,6 +43,19 @@ module Digest
       0xef1f, 0xff3e, 0xcf5d, 0xdf7c, 0xaf9b, 0xbfba, 0x8fd9, 0x9ff8,
       0x6e17, 0x7e36, 0x4e55, 0x5e74, 0x2e93, 0x3eb2, 0x0ed1, 0x1ef0
     ].freeze
+  end
+end
+
+if RUBY_ENGINE == 'ruby'
+  begin;
+    require 'digest/crc16_ccitt/crc16_ccitt_ext'
+    return
+  rescue LoadError
+  end
+end
+
+module Digest
+  class CRC16CCITT < CRC
 
     #
     # Updates the CRC16 CCITT checksum.
@@ -59,8 +72,4 @@ module Digest
     end
 
   end
-end
-
-if RUBY_ENGINE == 'ruby'
-  begin; require 'digest/crc16_ccitt/crc16_ccitt_ext'; rescue LoadError; end
 end

--- a/lib/digest/crc16_dnp.rb
+++ b/lib/digest/crc16_dnp.rb
@@ -43,6 +43,24 @@ module Digest
       0x91af,  0xa7f1,  0xfd13,  0xcb4d,  0x48d7,  0x7e89,  0x246b,  0x1235
     ].freeze
 
+    def finish
+      self.class.pack(~@crc)
+    end
+
+  end
+end
+
+if RUBY_ENGINE == 'ruby'
+  begin;
+    require 'digest/crc16_dnp/crc16_dnp_ext'
+    return
+  rescue LoadError
+  end
+end
+
+module Digest
+  class CRC16DNP
+
     #
     # Updates the CRC16 DNP checksum.
     #
@@ -57,13 +75,5 @@ module Digest
       return self
     end
 
-    def finish
-      self.class.pack(~@crc)
-    end
-
   end
-end
-
-if RUBY_ENGINE == 'ruby'
-  begin; require 'digest/crc16_dnp/crc16_dnp_ext'; rescue LoadError; end
 end

--- a/lib/digest/crc16_genibus.rb
+++ b/lib/digest/crc16_genibus.rb
@@ -49,6 +49,19 @@ module Digest
       0xef1f, 0xff3e, 0xcf5d, 0xdf7c, 0xaf9b, 0xbfba, 0x8fd9, 0x9ff8,
       0x6e17, 0x7e36, 0x4e55, 0x5e74, 0x2e93, 0x3eb2, 0x0ed1, 0x1ef0
     ].freeze
+  end
+end
+
+if RUBY_ENGINE == 'ruby'
+  begin;
+    require 'digest/crc16_genibus/crc16_genibus_ext'
+    return
+  rescue LoadError
+  end
+end
+
+module Digest
+  class CRC16Genibus
 
     #
     # Updates the CRC16 Genibus checksum.
@@ -65,8 +78,4 @@ module Digest
     end
 
   end
-end
-
-if RUBY_ENGINE == 'ruby'
-  begin; require 'digest/crc16_genibus/crc16_genibus_ext'; rescue LoadError; end
 end

--- a/lib/digest/crc16_kermit.rb
+++ b/lib/digest/crc16_kermit.rb
@@ -43,6 +43,19 @@ module Digest
       0xf78f, 0xe606, 0xd49d, 0xc514, 0xb1ab, 0xa022, 0x92b9, 0x8330,
       0x7bc7, 0x6a4e, 0x58d5, 0x495c, 0x3de3, 0x2c6a, 0x1ef1, 0x0f78
     ].freeze
+  end
+end
+
+if RUBY_ENGINE == 'ruby'
+  begin;
+    require 'digest/crc16_kermit/crc16_kermit_ext'
+    return
+  rescue LoadError
+  end
+end
+
+module Digest
+  class CRC16Kermit
 
     #
     # Updates the CRC16 Kermit checksum.
@@ -59,8 +72,4 @@ module Digest
     end
 
   end
-end
-
-if RUBY_ENGINE == 'ruby'
-  begin; require 'digest/crc16_kermit/crc16_kermit_ext'; rescue LoadError; end
 end

--- a/lib/digest/crc16_modbus.rb
+++ b/lib/digest/crc16_modbus.rb
@@ -48,5 +48,9 @@ module Digest
 end
 
 if RUBY_ENGINE == 'ruby'
-  begin; require 'digest/crc16_modbus/crc16_modbus_ext'; rescue LoadError; end
+  begin;
+    require 'digest/crc16_modbus/crc16_modbus_ext'
+    return
+  rescue LoadError
+  end
 end

--- a/lib/digest/crc16_usb.rb
+++ b/lib/digest/crc16_usb.rb
@@ -14,5 +14,9 @@ module Digest
 end
 
 if RUBY_ENGINE == 'ruby'
-  begin; require 'digest/crc16_usb/crc16_usb_ext'; rescue LoadError; end
+  begin;
+    require 'digest/crc16_usb/crc16_usb_ext'
+    return
+  rescue LoadError
+  end
 end

--- a/lib/digest/crc16_x_25.rb
+++ b/lib/digest/crc16_x_25.rb
@@ -47,10 +47,13 @@ module Digest
       0xf78f, 0xe606, 0xd49d, 0xc514, 0xb1ab, 0xa022, 0x92b9, 0x8330,
       0x7bc7, 0x6a4e, 0x58d5, 0x495c, 0x3de3, 0x2c6a, 0x1ef1, 0x0f78
     ].freeze
-    
   end
 end
 
 if RUBY_ENGINE == 'ruby'
-  begin; require 'digest/crc16_x_25/crc16_x_25_ext'; rescue LoadError; end
+  begin;
+    require 'digest/crc16_x_25/crc16_x_25_ext'
+    return
+  rescue LoadError
+  end
 end

--- a/lib/digest/crc16_xmodem.rb
+++ b/lib/digest/crc16_xmodem.rb
@@ -41,7 +41,19 @@ module Digest
       0xef1f, 0xff3e, 0xcf5d, 0xdf7c, 0xaf9b, 0xbfba, 0x8fd9, 0x9ff8,
       0x6e17, 0x7e36, 0x4e55, 0x5e74, 0x2e93, 0x3eb2, 0x0ed1, 0x1ef0
     ].freeze
+  end
+end
 
+if RUBY_ENGINE == 'ruby'
+  begin;
+    require 'digest/crc16_xmodem/crc16_xmodem_ext'
+    return
+  rescue LoadError
+  end
+end
+
+module Digest
+  class CRC16XModem
     #
     # Updates the CRC16 XModem checksum.
     #
@@ -57,8 +69,4 @@ module Digest
     end
 
   end
-end
-
-if RUBY_ENGINE == 'ruby'
-  begin; require 'digest/crc16_xmodem/crc16_xmodem_ext'; rescue LoadError; end
 end

--- a/lib/digest/crc16_zmodem.rb
+++ b/lib/digest/crc16_zmodem.rb
@@ -41,7 +41,19 @@ module Digest
       0xef1f, 0xff3e, 0xcf5d, 0xdf7c, 0xaf9b, 0xbfba, 0x8fd9, 0x9ff8,
       0x6e17, 0x7e36, 0x4e55, 0x5e74, 0x2e93, 0x3eb2, 0x0ed1, 0x1ef0
     ].freeze
+  end
+end
 
+if RUBY_ENGINE == 'ruby'
+  begin;
+    require 'digest/crc16_zmodem/crc16_zmodem_ext'
+    return
+  rescue LoadError
+  end
+end
+
+module Digest
+  class CRC16ZModem
     #
     # Updates the CRC16 checksum.
     #
@@ -57,8 +69,4 @@ module Digest
     end
 
   end
-end
-
-if RUBY_ENGINE == 'ruby'
-  begin; require 'digest/crc16_zmodem/crc16_zmodem_ext'; rescue LoadError; end
 end

--- a/lib/digest/crc24.rb
+++ b/lib/digest/crc24.rb
@@ -64,7 +64,19 @@ module Digest
 
       buffer
     end
+  end
+end
 
+if RUBY_ENGINE == 'ruby'
+  begin;
+    require 'digest/crc24/crc24_ext'
+    return
+  rescue LoadError
+  end
+end
+
+module Digest
+  class CRC24
     #
     # Updates the CRC24 checksum.
     #
@@ -80,8 +92,4 @@ module Digest
     end
 
   end
-end
-
-if RUBY_ENGINE == 'ruby'
-  begin; require 'digest/crc24/crc24_ext'; rescue LoadError; end
 end

--- a/lib/digest/crc32.rb
+++ b/lib/digest/crc32.rb
@@ -99,8 +99,21 @@ module Digest
 
       buffer
     end
+  end
+end
 
+if RUBY_ENGINE == 'ruby'
+  begin;
+    require 'digest/crc32/crc32_ext'
+    return
+  rescue LoadError
+  end
+end
+
+module Digest
+  class CRC32
     #
+    # @!method update
     # Updates the CRC32 checksum.
     #
     # @param [String] data
@@ -115,8 +128,4 @@ module Digest
     end
 
   end
-end
-
-if RUBY_ENGINE == 'ruby'
-  begin; require 'digest/crc32/crc32_ext'; rescue LoadError; end
 end

--- a/lib/digest/crc32_bzip2.rb
+++ b/lib/digest/crc32_bzip2.rb
@@ -41,7 +41,19 @@ module Digest
       0x89b8fd09, 0x8d79e0be, 0x803ac667, 0x84fbdbd0, 0x9abc8bd5, 0x9e7d9662, 0x933eb0bb, 0x97ffad0c,
       0xafb010b1, 0xab710d06, 0xa6322bdf, 0xa2f33668, 0xbcb4666d, 0xb8757bda, 0xb5365d03, 0xb1f740b4
     ].freeze
+  end
+end
 
+if RUBY_ENGINE == 'ruby'
+  begin;
+    require 'digest/crc32_bzip2/crc32_bzip2_ext'
+    return
+  rescue LoadError
+  end
+end
+
+module Digest
+  class CRC32BZip2
     #
     # Updates the CRC32 BZip2 checksum.
     #
@@ -57,8 +69,4 @@ module Digest
     end
 
   end
-end
-
-if RUBY_ENGINE == 'ruby'
-  begin; require 'digest/crc32_bzip2/crc32_bzip2_ext'; rescue LoadError; end
 end

--- a/lib/digest/crc32_mpeg.rb
+++ b/lib/digest/crc32_mpeg.rb
@@ -75,7 +75,23 @@ module Digest
       0xafb010b1, 0xab710d06, 0xa6322bdf, 0xa2f33668,
       0xbcb4666d, 0xb8757bda, 0xb5365d03, 0xb1f740b4
     ].freeze
+  end
+end
 
+if RUBY_ENGINE == 'ruby'
+  begin;
+    require 'digest/crc32_mpeg/crc32_mpeg_ext'
+    module Digest
+      # @deprecated Please use {CRC32MPEG}
+      CRC32Mpeg = CRC32MPEG
+    end
+    return
+  rescue LoadError
+  end
+end
+
+module Digest
+  class CRC32MPEG
     #
     # Updates the CRC32 Mpeg checksum.
     #
@@ -91,11 +107,6 @@ module Digest
     end
 
   end
-
   # @deprecated Please use {CRC32MPEG}.
   CRC32Mpeg = CRC32MPEG
-end
-
-if RUBY_ENGINE == 'ruby'
-  begin; require 'digest/crc32_mpeg/crc32_mpeg_ext'; rescue LoadError; end
 end

--- a/lib/digest/crc32_posix.rb
+++ b/lib/digest/crc32_posix.rb
@@ -42,7 +42,19 @@ module Digest
     0x89b8fd09, 0x8d79e0be, 0x803ac667, 0x84fbdbd0, 0x9abc8bd5, 0x9e7d9662, 0x933eb0bb, 0x97ffad0c,
     0xafb010b1, 0xab710d06, 0xa6322bdf, 0xa2f33668, 0xbcb4666d, 0xb8757bda, 0xb5365d03, 0xb1f740b4
     ].freeze
+  end
+end
 
+if RUBY_ENGINE == 'ruby'
+  begin;
+    require 'digest/crc32_posix/crc32_posix_ext'
+    return
+  rescue LoadError
+  end
+end
+
+module Digest
+  class CRC32POSIX
     #
     # Updates the CRC32 POSIX checksum.
     #
@@ -58,8 +70,4 @@ module Digest
     end
 
   end
-end
-
-if RUBY_ENGINE == 'ruby'
-  begin; require 'digest/crc32_posix/crc32_posix_ext'; rescue LoadError; end
 end

--- a/lib/digest/crc32_xfer.rb
+++ b/lib/digest/crc32_xfer.rb
@@ -45,7 +45,19 @@ module Digest
       0x00006350, 0x000063ff, 0x0000620e, 0x000062a1, 0x000061ec, 0x00006143, 0x000060b2, 0x0000601d,
       0x00006628, 0x00006687, 0x00006776, 0x000067d9, 0x00006494, 0x0000643b, 0x000065ca, 0x00006565
     ].freeze
+  end
+end
 
+if RUBY_ENGINE == 'ruby'
+  begin;
+    require 'digest/crc32_xfer/crc32_xfer_ext'
+    return
+  rescue LoadError
+  end
+end
+
+module  Digest
+  class CRC32XFER
     #
     # Updates the CRC32 XFER checksum.
     #
@@ -61,8 +73,4 @@ module Digest
     end
 
   end
-end
-
-if RUBY_ENGINE == 'ruby'
-  begin; require 'digest/crc32_xfer/crc32_xfer_ext'; rescue LoadError; end
 end

--- a/lib/digest/crc32c.rb
+++ b/lib/digest/crc32c.rb
@@ -78,5 +78,9 @@ module Digest
 end
 
 if RUBY_ENGINE == 'ruby'
-  begin; require 'digest/crc32c/crc32c_ext'; rescue LoadError; end
+  begin;
+    require 'digest/crc32c/crc32c_ext'
+    return
+  rescue LoadError
+  end
 end

--- a/lib/digest/crc5.rb
+++ b/lib/digest/crc5.rb
@@ -55,7 +55,19 @@ module Digest
     def self.pack(crc)
       (crc & CRC_MASK).chr
     end
+  end
+end
 
+if RUBY_ENGINE == 'ruby'
+  begin;
+    require 'digest/crc5/crc5_ext'
+    return
+  rescue LoadError
+  end
+end
+
+module Digest
+  class CRC5
     #
     # Updates the CRC5 checksum.
     #
@@ -71,8 +83,4 @@ module Digest
     end
 
   end
-end
-
-if RUBY_ENGINE == 'ruby'
-  begin; require 'digest/crc5/crc5_ext'; rescue LoadError; end
 end

--- a/lib/digest/crc64.rb
+++ b/lib/digest/crc64.rb
@@ -103,7 +103,19 @@ module Digest
 
       buffer
     end
+  end
+end
 
+if RUBY_ENGINE == 'ruby'
+  begin;
+    require 'digest/crc64/crc64_ext'
+    return
+  rescue LoadError
+  end
+end
+
+module Digest
+  class CRC64
     #
     # Updates the CRC64 checksum.
     #
@@ -119,8 +131,4 @@ module Digest
     end
 
   end
-end
-
-if RUBY_ENGINE == 'ruby'
-  begin; require 'digest/crc64/crc64_ext'; rescue LoadError; end
 end

--- a/lib/digest/crc64_jones.rb
+++ b/lib/digest/crc64_jones.rb
@@ -84,5 +84,9 @@ module Digest
 end
 
 if RUBY_ENGINE == 'ruby'
-  begin; require 'digest/crc64_jones/crc64_jones_ext'; rescue LoadError; end
+  begin;
+    require 'digest/crc64_jones/crc64_jones_ext'
+    return
+  rescue LoadError
+  end
 end

--- a/lib/digest/crc64_xz.rb
+++ b/lib/digest/crc64_xz.rb
@@ -86,5 +86,9 @@ module Digest
 end
 
 if RUBY_ENGINE == 'ruby'
-  begin; require 'digest/crc64_xz/crc64_xz_ext'; rescue LoadError; end
+  begin;
+    require 'digest/crc64_xz/crc64_xz_ext'
+    return
+  rescue LoadError
+  end
 end

--- a/lib/digest/crc8.rb
+++ b/lib/digest/crc8.rb
@@ -42,7 +42,19 @@ module Digest
     def self.pack(crc)
       (crc & 0xff).chr
     end
+  end
+end
 
+if RUBY_ENGINE == 'ruby'
+  begin;
+    require 'digest/crc8/crc8_ext'
+    return
+  rescue LoadError
+  end
+end
+
+module Digest
+  class CRC8
     #
     # Updates the CRC8 checksum.
     #
@@ -58,8 +70,4 @@ module Digest
     end
 
   end
-end
-
-if RUBY_ENGINE == 'ruby'
-  begin; require 'digest/crc8/crc8_ext'; rescue LoadError; end
 end

--- a/lib/digest/crc8_1wire.rb
+++ b/lib/digest/crc8_1wire.rb
@@ -33,5 +33,9 @@ module Digest
 end
 
 if RUBY_ENGINE == 'ruby'
-  begin; require 'digest/crc8_1wire/crc8_1wire_ext'; rescue LoadError; end
+  begin;
+    require 'digest/crc8_1wire/crc8_1wire_ext'
+    return
+  rescue LoadError
+  end
 end


### PR DESCRIPTION
Right now we have
```
irb(main):001:0> require 'digest/crc32'
/home/ojab/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/digest-crc-0.6.3/ext/digest/crc32/crc32_ext.so: warning: method redefined; discarding old update
/home/ojab/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/digest-crc-0.6.3/lib/digest/crc32.rb:109: warning: previous definition of update was here
```