### PR TITLE
Mark native extension as "Ractor-safe"

### DIFF
--- a/ext/digest/crc12_3gpp/crc12_3gpp_ext.c
+++ b/ext/digest/crc12_3gpp/crc12_3gpp_ext.c
@@ -23,6 +23,10 @@ void Init_crc12_3gpp_ext()
 	VALUE mDigest = rb_const_get(rb_cObject, rb_intern("Digest"));
 	VALUE cCRC12_3GPP = rb_const_get(mDigest, rb_intern("CRC12_3GPP"));
 
+	#ifdef HAVE_RB_EXT_RACTOR_SAFE
+		rb_ext_ractor_safe(true);
+	#endif
+
 	rb_undef_method(cCRC12_3GPP, "update");
 	rb_define_method(cCRC12_3GPP, "update", Digest_CRC12_3GPP_update, 1);
 }

--- a/ext/digest/crc15/crc15_ext.c
+++ b/ext/digest/crc15/crc15_ext.c
@@ -24,6 +24,10 @@ void Init_crc15_ext()
 	VALUE mDigest = rb_const_get(rb_cObject, rb_intern("Digest"));
 	VALUE cCRC15 = rb_const_get(mDigest, rb_intern("CRC15"));
 
+	#ifdef HAVE_RB_EXT_RACTOR_SAFE
+		rb_ext_ractor_safe(true);
+	#endif
+
 	rb_undef_method(cCRC15, "update");
 	rb_define_method(cCRC15, "update", Digest_CRC15_update, 1);
 }

--- a/ext/digest/crc16/crc16_ext.c
+++ b/ext/digest/crc16/crc16_ext.c
@@ -24,6 +24,10 @@ void Init_crc16_ext()
 	VALUE mDigest = rb_const_get(rb_cObject, rb_intern("Digest"));
 	VALUE cCRC16 = rb_const_get(mDigest, rb_intern("CRC16"));
 
+	#ifdef HAVE_RB_EXT_RACTOR_SAFE
+		rb_ext_ractor_safe(true);
+	#endif
+
 	rb_undef_method(cCRC16, "update");
 	rb_define_method(cCRC16, "update", Digest_CRC16_update, 1);
 }

--- a/ext/digest/crc16_ccitt/crc16_ccitt_ext.c
+++ b/ext/digest/crc16_ccitt/crc16_ccitt_ext.c
@@ -24,6 +24,10 @@ void Init_crc16_ccitt_ext()
 	VALUE mDigest = rb_const_get(rb_cObject, rb_intern("Digest"));
 	VALUE cCRC16CCITT = rb_const_get(mDigest, rb_intern("CRC16CCITT"));
 
+	#ifdef HAVE_RB_EXT_RACTOR_SAFE
+		rb_ext_ractor_safe(true);
+	#endif
+
 	rb_undef_method(cCRC16CCITT, "update");
 	rb_define_method(cCRC16CCITT, "update", Digest_CRC16CCITT_update, 1);
 }

--- a/ext/digest/crc16_dnp/crc16_dnp_ext.c
+++ b/ext/digest/crc16_dnp/crc16_dnp_ext.c
@@ -24,6 +24,10 @@ void Init_crc16_dnp_ext()
 	VALUE mDigest = rb_const_get(rb_cObject, rb_intern("Digest"));
 	VALUE cCRC16DNP = rb_const_get(mDigest, rb_intern("CRC16DNP"));
 
+	#ifdef HAVE_RB_EXT_RACTOR_SAFE
+		rb_ext_ractor_safe(true);
+	#endif
+
 	rb_undef_method(cCRC16DNP, "update");
 	rb_define_method(cCRC16DNP, "update", Digest_CRC16DNP_update, 1);
 }

--- a/ext/digest/crc16_genibus/crc16_genibus_ext.c
+++ b/ext/digest/crc16_genibus/crc16_genibus_ext.c
@@ -24,6 +24,10 @@ void Init_crc16_genibus_ext()
 	VALUE mDigest = rb_const_get(rb_cObject, rb_intern("Digest"));
 	VALUE cCRC16Genibus = rb_const_get(mDigest, rb_intern("CRC16Genibus"));
 
+	#ifdef HAVE_RB_EXT_RACTOR_SAFE
+		rb_ext_ractor_safe(true);
+	#endif
+
 	rb_undef_method(cCRC16Genibus, "update");
 	rb_define_method(cCRC16Genibus, "update", Digest_CRC16Genibus_update, 1);
 }

--- a/ext/digest/crc16_kermit/crc16_kermit_ext.c
+++ b/ext/digest/crc16_kermit/crc16_kermit_ext.c
@@ -24,6 +24,10 @@ void Init_crc16_kermit_ext()
 	VALUE mDigest = rb_const_get(rb_cObject, rb_intern("Digest"));
 	VALUE cCRC16Kermit = rb_const_get(mDigest, rb_intern("CRC16Kermit"));
 
+	#ifdef HAVE_RB_EXT_RACTOR_SAFE
+		rb_ext_ractor_safe(true);
+	#endif
+
 	rb_undef_method(cCRC16Kermit, "update");
 	rb_define_method(cCRC16Kermit, "update", Digest_CRC16Kermit_update, 1);
 }

--- a/ext/digest/crc16_modbus/crc16_modbus_ext.c
+++ b/ext/digest/crc16_modbus/crc16_modbus_ext.c
@@ -24,5 +24,9 @@ void Init_crc16_modbus_ext()
 	VALUE mDigest = rb_const_get(rb_cObject, rb_intern("Digest"));
 	VALUE cCRC16Modbus = rb_const_get(mDigest, rb_intern("CRC16Modbus"));
 
+	#ifdef HAVE_RB_EXT_RACTOR_SAFE
+		rb_ext_ractor_safe(true);
+	#endif
+
 	rb_define_method(cCRC16Modbus, "update", Digest_CRC16Modbus_update, 1);
 }

--- a/ext/digest/crc16_usb/crc16_usb_ext.c
+++ b/ext/digest/crc16_usb/crc16_usb_ext.c
@@ -24,5 +24,9 @@ void Init_crc16_usb_ext()
 	VALUE mDigest = rb_const_get(rb_cObject, rb_intern("Digest"));
 	VALUE cCRC16USB = rb_const_get(mDigest, rb_intern("CRC16USB"));
 
+	#ifdef HAVE_RB_EXT_RACTOR_SAFE
+		rb_ext_ractor_safe(true);
+	#endif
+
 	rb_define_method(cCRC16USB, "update", Digest_CRC16USB_update, 1);
 }

--- a/ext/digest/crc16_x_25/crc16_x_25_ext.c
+++ b/ext/digest/crc16_x_25/crc16_x_25_ext.c
@@ -24,5 +24,9 @@ void Init_crc16_x_25_ext()
 	VALUE mDigest = rb_const_get(rb_cObject, rb_intern("Digest"));
 	VALUE cCRC16X25 = rb_const_get(mDigest, rb_intern("CRC16X25"));
 
+	#ifdef HAVE_RB_EXT_RACTOR_SAFE
+		rb_ext_ractor_safe(true);
+	#endif
+
 	rb_define_method(cCRC16X25, "update", Digest_CRC16X25_update, 1);
 }

--- a/ext/digest/crc16_xmodem/crc16_xmodem_ext.c
+++ b/ext/digest/crc16_xmodem/crc16_xmodem_ext.c
@@ -24,6 +24,10 @@ void Init_crc16_xmodem_ext()
 	VALUE mDigest = rb_const_get(rb_cObject, rb_intern("Digest"));
 	VALUE cCRC16XModem = rb_const_get(mDigest, rb_intern("CRC16XModem"));
 
+	#ifdef HAVE_RB_EXT_RACTOR_SAFE
+		rb_ext_ractor_safe(true);
+	#endif
+
 	rb_undef_method(cCRC16XModem, "update");
 	rb_define_method(cCRC16XModem, "update", Digest_CRC16XModem_update, 1);
 }

--- a/ext/digest/crc16_zmodem/crc16_zmodem_ext.c
+++ b/ext/digest/crc16_zmodem/crc16_zmodem_ext.c
@@ -24,6 +24,10 @@ void Init_crc16_zmodem_ext()
 	VALUE mDigest = rb_const_get(rb_cObject, rb_intern("Digest"));
 	VALUE cCRC16ZModem = rb_const_get(mDigest, rb_intern("CRC16ZModem"));
 
+	#ifdef HAVE_RB_EXT_RACTOR_SAFE
+		rb_ext_ractor_safe(true);
+	#endif
+
 	rb_undef_method(cCRC16ZModem, "update");
 	rb_define_method(cCRC16ZModem, "update", Digest_CRC16ZModem_update, 1);
 }

--- a/ext/digest/crc24/crc24_ext.c
+++ b/ext/digest/crc24/crc24_ext.c
@@ -23,6 +23,10 @@ void Init_crc24_ext()
 	VALUE mDigest = rb_const_get(rb_cObject, rb_intern("Digest"));
 	VALUE cCRC24 = rb_const_get(mDigest, rb_intern("CRC24"));
 
+	#ifdef HAVE_RB_EXT_RACTOR_SAFE
+		rb_ext_ractor_safe(true);
+	#endif
+
 	rb_undef_method(cCRC24, "update");
 	rb_define_method(cCRC24, "update", Digest_CRC24_update, 1);
 }

--- a/ext/digest/crc32/crc32_ext.c
+++ b/ext/digest/crc32/crc32_ext.c
@@ -23,6 +23,10 @@ void Init_crc32_ext()
 	VALUE mDigest = rb_const_get(rb_cObject, rb_intern("Digest"));
 	VALUE cCRC32 = rb_const_get(mDigest, rb_intern("CRC32"));
 
+	#ifdef HAVE_RB_EXT_RACTOR_SAFE
+		rb_ext_ractor_safe(true);
+	#endif
+
 	rb_undef_method(cCRC32, "update");
 	rb_define_method(cCRC32, "update", Digest_CRC32_update, 1);
 }

--- a/ext/digest/crc32_bzip2/crc32_bzip2_ext.c
+++ b/ext/digest/crc32_bzip2/crc32_bzip2_ext.c
@@ -23,6 +23,10 @@ void Init_crc32_bzip2_ext()
 	VALUE mDigest = rb_const_get(rb_cObject, rb_intern("Digest"));
 	VALUE cCRC32Bzip2 = rb_const_get(mDigest, rb_intern("CRC32BZip2"));
 
+	#ifdef HAVE_RB_EXT_RACTOR_SAFE
+		rb_ext_ractor_safe(true);
+	#endif
+
 	rb_undef_method(cCRC32Bzip2, "update");
 	rb_define_method(cCRC32Bzip2, "update", Digest_CRC32Bzip2_update, 1);
 }

--- a/ext/digest/crc32_jam/crc32_jam_ext.c
+++ b/ext/digest/crc32_jam/crc32_jam_ext.c
@@ -23,5 +23,9 @@ void Init_crc32_jam_ext()
 	VALUE mDigest = rb_const_get(rb_cObject, rb_intern("Digest"));
 	VALUE cCRC32Jam = rb_const_get(mDigest, rb_intern("CRC32Jam"));
 
+	#ifdef HAVE_RB_EXT_RACTOR_SAFE
+		rb_ext_ractor_safe(true);
+	#endif
+
 	rb_define_method(cCRC32Jam, "update", Digest_CRC32Jam_update, 1);
 }

--- a/ext/digest/crc32_mpeg/crc32_mpeg_ext.c
+++ b/ext/digest/crc32_mpeg/crc32_mpeg_ext.c
@@ -23,6 +23,10 @@ void Init_crc32_mpeg_ext()
 	VALUE mDigest = rb_const_get(rb_cObject, rb_intern("Digest"));
 	VALUE cCRC32MPEG = rb_const_get(mDigest, rb_intern("CRC32MPEG"));
 
+	#ifdef HAVE_RB_EXT_RACTOR_SAFE
+		rb_ext_ractor_safe(true);
+	#endif
+
 	rb_undef_method(cCRC32MPEG, "update");
 	rb_define_method(cCRC32MPEG, "update", Digest_CRC32MPEG_update, 1);
 }

--- a/ext/digest/crc32_posix/crc32_posix_ext.c
+++ b/ext/digest/crc32_posix/crc32_posix_ext.c
@@ -23,6 +23,10 @@ void Init_crc32_posix_ext()
 	VALUE mDigest = rb_const_get(rb_cObject, rb_intern("Digest"));
 	VALUE cCRC32POSIX = rb_const_get(mDigest, rb_intern("CRC32POSIX"));
 
+	#ifdef HAVE_RB_EXT_RACTOR_SAFE
+		rb_ext_ractor_safe(true);
+	#endif
+
 	rb_undef_method(cCRC32POSIX, "update");
 	rb_define_method(cCRC32POSIX, "update", Digest_CRC32POSIX_update, 1);
 }

--- a/ext/digest/crc32_xfer/crc32_xfer_ext.c
+++ b/ext/digest/crc32_xfer/crc32_xfer_ext.c
@@ -23,6 +23,10 @@ void Init_crc32_xfer_ext()
 	VALUE mDigest = rb_const_get(rb_cObject, rb_intern("Digest"));
 	VALUE cCRC32XFER = rb_const_get(mDigest, rb_intern("CRC32XFER"));
 
+	#ifdef HAVE_RB_EXT_RACTOR_SAFE
+		rb_ext_ractor_safe(true);
+	#endif
+
 	rb_undef_method(cCRC32XFER, "update");
 	rb_define_method(cCRC32XFER, "update", Digest_CRC32XFER_update, 1);
 }

--- a/ext/digest/crc32c/crc32c_ext.c
+++ b/ext/digest/crc32c/crc32c_ext.c
@@ -23,5 +23,9 @@ void Init_crc32c_ext()
 	VALUE mDigest = rb_const_get(rb_cObject, rb_intern("Digest"));
 	VALUE cCRC32c = rb_const_get(mDigest, rb_intern("CRC32c"));
 
+	#ifdef HAVE_RB_EXT_RACTOR_SAFE
+		rb_ext_ractor_safe(true);
+	#endif
+
 	rb_define_method(cCRC32c, "update", Digest_CRC32c_update, 1);
 }

--- a/ext/digest/crc5/crc5_ext.c
+++ b/ext/digest/crc5/crc5_ext.c
@@ -23,6 +23,10 @@ void Init_crc5_ext()
 	VALUE mDigest = rb_const_get(rb_cObject, rb_intern("Digest"));
 	VALUE cCRC5 = rb_const_get(mDigest, rb_intern("CRC5"));
 
+	#ifdef HAVE_RB_EXT_RACTOR_SAFE
+		rb_ext_ractor_safe(true);
+	#endif
+
 	rb_undef_method(cCRC5, "update");
 	rb_define_method(cCRC5, "update", Digest_CRC5_update, 1);
 }

--- a/ext/digest/crc64/crc64_ext.c
+++ b/ext/digest/crc64/crc64_ext.c
@@ -23,6 +23,10 @@ void Init_crc64_ext()
 	VALUE mDigest = rb_const_get(rb_cObject, rb_intern("Digest"));
 	VALUE cCRC64 = rb_const_get(mDigest, rb_intern("CRC64"));
 
+	#ifdef HAVE_RB_EXT_RACTOR_SAFE
+		rb_ext_ractor_safe(true);
+	#endif
+
 	rb_undef_method(cCRC64, "update");
 	rb_define_method(cCRC64, "update", Digest_CRC64_update, 1);
 }

--- a/ext/digest/crc64_jones/crc64_jones_ext.c
+++ b/ext/digest/crc64_jones/crc64_jones_ext.c
@@ -23,5 +23,9 @@ void Init_crc64_jones_ext()
 	VALUE mDigest = rb_const_get(rb_cObject, rb_intern("Digest"));
 	VALUE cCRC64Jones = rb_const_get(mDigest, rb_intern("CRC64Jones"));
 
+	#ifdef HAVE_RB_EXT_RACTOR_SAFE
+		rb_ext_ractor_safe(true);
+	#endif
+
 	rb_define_method(cCRC64Jones, "update", Digest_CRC64Jones_update, 1);
 }

--- a/ext/digest/crc64_xz/crc64_xz_ext.c
+++ b/ext/digest/crc64_xz/crc64_xz_ext.c
@@ -23,5 +23,9 @@ void Init_crc64_xz_ext()
 	VALUE mDigest = rb_const_get(rb_cObject, rb_intern("Digest"));
 	VALUE cCRC64XZ = rb_const_get(mDigest, rb_intern("CRC64XZ"));
 
+	#ifdef HAVE_RB_EXT_RACTOR_SAFE
+		rb_ext_ractor_safe(true);
+	#endif
+
 	rb_define_method(cCRC64XZ, "update", Digest_CRC64XZ_update, 1);
 }

--- a/ext/digest/crc8/crc8_ext.c
+++ b/ext/digest/crc8/crc8_ext.c
@@ -23,6 +23,10 @@ void Init_crc8_ext()
 	VALUE mDigest = rb_const_get(rb_cObject, rb_intern("Digest"));
 	VALUE cCRC8 = rb_const_get(mDigest, rb_intern("CRC8"));
 
+	#ifdef HAVE_RB_EXT_RACTOR_SAFE
+		rb_ext_ractor_safe(true);
+	#endif
+
 	rb_undef_method(cCRC8, "update");
 	rb_define_method(cCRC8, "update", Digest_CRC8_update, 1);
 }

--- a/ext/digest/crc8_1wire/crc8_1wire_ext.c
+++ b/ext/digest/crc8_1wire/crc8_1wire_ext.c
@@ -23,5 +23,9 @@ void Init_crc8_1wire_ext()
 	VALUE mDigest = rb_const_get(rb_cObject, rb_intern("Digest"));
 	VALUE cCRC81Wire = rb_const_get(mDigest, rb_intern("CRC8_1Wire"));
 
+	#ifdef HAVE_RB_EXT_RACTOR_SAFE
+		rb_ext_ractor_safe(true);
+	#endif
+
 	rb_define_method(cCRC81Wire, "update", Digest_CRC81Wire_update, 1);
 }

--- a/spec/crc_examples.rb
+++ b/spec/crc_examples.rb
@@ -24,4 +24,14 @@ shared_examples_for "CRC" do
 
     expect(crc.checksum).to be == expected.to_i(16)
   end
+
+  if defined?(Ractor)
+    it "should calculate CRC inside ractor" do
+      digest = Ractor.new(described_class, string) do |klass, string|
+        klass.hexdigest(string)
+      end.take
+
+      expect(digest).to eq expected
+    end
+  end
 end


### PR DESCRIPTION
I looked up the code how the ruby Digest module was made "ractor safe" and applied it to this module.