### PR TITLE
Unified `CRC.pack`

### DIFF
--- a/lib/digest/crc.rb
+++ b/lib/digest/crc.rb
@@ -45,10 +45,15 @@ module Digest
     # @return [String]
     #   The packed CRC checksum.
     #
-    # @abstract
-    #
     def self.pack(crc)
-      raise(NotImplementedError,"#{self.class}##{__method__} not implemented")
+      width = self::WIDTH
+      raise(NotImplementedError, "#{self} is incompleted as CRC") unless width > 0
+      bitclass = width + (-width & 0x07)
+      len = bitclass / 8
+      crc = ~(-1 << width) & crc
+      result = [crc].pack("Q>")
+      result[0, result.size - len] = ""
+      result
     end
 
     #

--- a/lib/digest/crc1.rb
+++ b/lib/digest/crc1.rb
@@ -6,6 +6,8 @@ module Digest
   #
   class CRC1 < CRC
 
+    WIDTH = 1
+
     #
     # Packs the CRC1 checksum.
     #

--- a/lib/digest/crc15.rb
+++ b/lib/digest/crc15.rb
@@ -31,24 +31,6 @@ module Digest
     ].freeze
 
     #
-    # Packs the CRC15 checksum.
-    #
-    # @param [Integer] crc
-    #   The CRC15 checksum to pack.
-    #
-    # @return [String]
-    #   The packed CRC15 checksum.
-    #
-    def self.pack(crc)
-      buffer = ''
-
-      buffer << ((crc & 0x7f00) >> 8).chr
-      buffer << (crc & 0xff).chr
-
-      buffer
-    end
-
-    #
     # Updates the CRC15 checksum.
     #
     # @param [String] data

--- a/lib/digest/crc16.rb
+++ b/lib/digest/crc16.rb
@@ -47,24 +47,6 @@ module Digest
     ].freeze
 
     #
-    # Packs the CRC16 checksum.
-    #
-    # @param [Integer] crc
-    #   The CRC16 checksum to pack.
-    #
-    # @return [String]
-    #   The packed CRC16 checksum.
-    #
-    def self.pack(crc)
-      buffer = ''
-
-      buffer << ((crc & 0xff00) >> 8).chr
-      buffer << (crc & 0xff).chr
-
-      buffer
-    end
-
-    #
     # Updates the CRC16 checksum.
     #
     # @param [String] data

--- a/lib/digest/crc24.rb
+++ b/lib/digest/crc24.rb
@@ -47,25 +47,6 @@ module Digest
     ].freeze
 
     #
-    # Packs the CRC24 checksum.
-    #
-    # @param [Integer] crc
-    #   The checksum to pack.
-    #
-    # @return [String]
-    #   The packed checksum.
-    #
-    def self.pack(crc)
-      buffer = ''
-
-      buffer << ((crc & 0xff0000) >> 16).chr
-      buffer << ((crc & 0x00ff00) >> 8).chr
-      buffer << (crc & 0x0000ff).chr
-
-      buffer
-    end
-
-    #
     # Updates the CRC24 checksum.
     #
     # @param [String] data

--- a/lib/digest/crc32.rb
+++ b/lib/digest/crc32.rb
@@ -81,26 +81,6 @@ module Digest
     ].freeze
 
     #
-    # Packs the CRC32 checksum.
-    #
-    # @param [Integer] crc
-    #   The checksum to pack.
-    #
-    # @return [String]
-    #   The packed checksum.
-    #
-    def self.pack(crc)
-      buffer = ''
-
-      buffer << ((crc & 0xff000000) >> 24).chr
-      buffer << ((crc & 0xff0000) >> 16).chr
-      buffer << ((crc & 0xff00) >> 8).chr
-      buffer << (crc & 0xff).chr
-
-      buffer
-    end
-
-    #
     # Updates the CRC32 checksum.
     #
     # @param [String] data

--- a/lib/digest/crc5.rb
+++ b/lib/digest/crc5.rb
@@ -44,19 +44,6 @@ module Digest
     end
 
     #
-    # Packs the CRC8 checksum.
-    #
-    # @param [Integer] crc
-    #   The checksum to pack.
-    #
-    # @return [String]
-    #   The packed checksum.
-    #
-    def self.pack(crc)
-      (crc & CRC_MASK).chr
-    end
-
-    #
     # Updates the CRC5 checksum.
     #
     # @param [String] data

--- a/lib/digest/crc64.rb
+++ b/lib/digest/crc64.rb
@@ -81,30 +81,6 @@ module Digest
     ].freeze
 
     #
-    # Packs the CRC64 checksum.
-    #
-    # @param [Integer] crc
-    #   The checksum to pack.
-    #
-    # @return [String]
-    #   The packed checksum.
-    #
-    def self.pack(crc)
-      buffer = ''
-
-      buffer << ((crc & 0xff00000000000000) >> 56).chr
-      buffer << ((crc & 0xff000000000000) >> 48).chr
-      buffer << ((crc & 0xff0000000000) >> 40).chr
-      buffer << ((crc & 0xff00000000) >> 32).chr
-      buffer << ((crc & 0xff000000) >> 24).chr
-      buffer << ((crc & 0xff0000) >> 16).chr
-      buffer << ((crc & 0xff00) >> 8).chr
-      buffer << (crc & 0xff).chr
-
-      buffer
-    end
-
-    #
     # Updates the CRC64 checksum.
     #
     # @param [String] data

--- a/lib/digest/crc8.rb
+++ b/lib/digest/crc8.rb
@@ -31,19 +31,6 @@ module Digest
     ].freeze
 
     #
-    # Packs the CRC8 checksum.
-    #
-    # @param [Integer] crc
-    #   The checksum to pack.
-    #
-    # @return [String]
-    #   The packed checksum.
-    #
-    def self.pack(crc)
-      (crc & 0xff).chr
-    end
-
-    #
     # Updates the CRC8 checksum.
     #
     # @param [String] data

--- a/spec/crc_examples.rb
+++ b/spec/crc_examples.rb
@@ -25,6 +25,34 @@ shared_examples_for "CRC" do
     expect(crc.checksum).to be == expected.to_i(16)
   end
 
+  it "should be the length of the result of pack, based on width, and expressed in big endian" do
+    code = 0xf0f1f2f3f4f5f6f7f8f9fafbfcfdfeff
+
+    case described_class::WIDTH
+    when 1
+      # NOTE: The current Digest::CRC1 is an 8-bit checksum, so this code may change in the future
+      digest = "\xff".b
+    when 5
+      digest = "\x1f".b
+    when 8
+      digest = "\xff".b
+    when 15
+      digest = "\x7e\xff".b
+    when 16
+      digest = "\xfe\xff".b
+    when 24
+      digest = "\xfd\xfe\xff".b
+    when 32
+      digest = "\xfc\xfd\xfe\xff".b
+    when 64
+      digest = "\xf8\xf9\xfa\xfb\xfc\xfd\xfe\xff".b
+    else
+      raise "Need to enhance specs for unanticipated number of bits (for WIDTH is #{described_class::WIDTH})"
+    end
+
+    expect(described_class.pack(code)).to be == digest
+  end
+
   if defined?(Ractor)
     it "should calculate CRC inside ractor" do
       digest = Ractor.new(described_class, string) do |klass, string|


### PR DESCRIPTION
It is no longer necessary to define a separate `.pack` method if the `WIDTH` constant is defined in a separate CRC class.
As in the past, the user can define a specific method for the truly special ones.

---

Since no merge conflicts seem to occur, I will submit it as a pull request.
