### PR TITLE
Fix `Digest::CRC16DNP

### DIFF
--- a/ext/digest/crc16_dnp/crc16_dnp.c
+++ b/ext/digest/crc16_dnp/crc16_dnp.c
@@ -46,7 +46,7 @@ crc16_t crc16_dnp_update(crc16_t crc, const void *data, size_t data_len)
 	while (data_len--)
 	{
 		tbl_idx = (crc ^ *d) & 0xff;
-		crc = (crc << 8) ^ crc16_dnp_table[tbl_idx];
+		crc = (crc >> 8) ^ crc16_dnp_table[tbl_idx];
 		d++;
 	}
 

--- a/lib/digest/crc16_dnp.rb
+++ b/lib/digest/crc16_dnp.rb
@@ -8,6 +8,8 @@ module Digest
 
     INIT_CRC = 0
 
+    XOR_MASK = 0xffff
+
     TABLE = [
       0x0000,  0x365e,  0x6cbc,  0x5ae2,  0xd978,  0xef26,  0xb5c4,  0x839a,
       0xff89,  0xc9d7,  0x9335,  0xa56b,  0x26f1,  0x10af,  0x4a4d,  0x7c13,
@@ -55,10 +57,6 @@ module Digest
       end
 
       return self
-    end
-
-    def finish
-      self.class.pack(~@crc)
     end
 
   end

--- a/spec/crc16_dnp_spec.rb
+++ b/spec/crc16_dnp_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+require 'crc_examples'
+require 'digest/crc16_dnp'
+
+describe Digest::CRC16DNP do
+  let(:string)   { '1234567890' }
+  let(:expected) { 'bc1b' }
+
+  it_should_behave_like "CRC"
+end


### PR DESCRIPTION
  - Set `XOR_MASK` instead of flipping bits in `Digest::CRC16DNP#finish`.
  - `Digest::CRC16DNP#update` does a right bit shift in `lib/digest/crc16_dnp.rb`.
    However, the C implementation did a left bit shift.
    For reference, CRC-16/DNP seems to input bits in reverse order (lower bits).
    https://reveng.sourceforge.io/crc-catalogue/16.htm#crc.cat.crc-16-dnp