### PR TITLE
Exclude spec files from gem package

### DIFF
--- a/digest-crc.gemspec
+++ b/digest-crc.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
 
   glob = lambda { |patterns| gem.files & Dir[*patterns] }
 
-  gem.files = `git ls-files`.split($/)
+  gem.files = `git ls-files`.split($/).grep_v(/^spec\//)
   gem.files = glob[gemspec['files']] if gemspec['files']
 
   gem.executables = gemspec.fetch('executables') do


### PR DESCRIPTION
Here's a patch that excludes files under spec directory from the gem package.

With this patch, the gem package size shrinks as follows:
```
before: 69632 bytes
after:  66048 bytes
```