### PR TITLE
Update bundler version to allow 4.0

### DIFF
--- a/gemspec.yml
+++ b/gemspec.yml
@@ -25,4 +25,4 @@ dependencies:
   rake: ">= 12.0.0, < 14.0.0"
 
 development_dependencies:
-  bundler: ~> 2.0
+  bundler: '>= 2.0'


### PR DESCRIPTION
Some distributions (like Arch Linux) ship newer Bundler (eg. 4.0) which causes `rake spec` to fail due to this Bundler version requirement.

Without this change `rake spec` fails with
```
Could not find compatible versions

Because the current Bundler version (4.0.3) does not satisfy bundler ~> 2.0
  and Gemfile depends on bundler ~> 2.0,
  version solving has failed.

Your bundle requires a different version of Bundler than the one you're running, and that version could not be found.
```
